### PR TITLE
libuuu: usb hotplug: configurable usb polling period (-pp)

### DIFF
--- a/libuuu/libuuu.h
+++ b/libuuu/libuuu.h
@@ -129,6 +129,8 @@ int uuu_add_usbpath_filter(const char *path);
 
 /*Set timeout wait for known devices appeared*/
 int uuu_set_wait_timeout(int second);
+/*Set usb device polling period */
+void uuu_set_poll_period(int msecond);
 /*
  * bit 0:15 for libusb
  * bit 16:31 for uuu

--- a/libuuu/usbhotplug.cpp
+++ b/libuuu/usbhotplug.cpp
@@ -50,6 +50,7 @@ static vector<thread> g_running_thread;
 static vector<string> g_filter_usbpath;
 
 static int g_wait_usb_timeout = -1;
+static int g_usb_poll_period = 0;
 
 static int g_known_device_appeared;
 
@@ -153,7 +154,8 @@ static int usb_add(libusb_device *dev)
 		return -1;
 
 	ConfigItem *item = get_config()->find(desc.idVendor, desc.idProduct, desc.bcdDevice);
-	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	int poll = g_usb_poll_period ? g_usb_poll_period : 200;
+	std::this_thread::sleep_for(std::chrono::milliseconds(poll));
 
 	if (item)
 	{
@@ -245,7 +247,8 @@ int polling_usb(std::atomic<int>& bexit)
 
 		oldlist = newlist;
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(200));
+		int poll = g_usb_poll_period ? g_usb_poll_period : 200;
+		std::this_thread::sleep_for(std::chrono::milliseconds(poll));
 
 		if (g_wait_usb_timeout >= 0 && !g_known_device_appeared)
 		{
@@ -408,4 +411,9 @@ int uuu_set_wait_timeout(int second)
 {
 	g_wait_usb_timeout = second;
 	return 0;
+}
+
+void uuu_set_poll_period(int msecond)
+{
+	g_usb_poll_period = msecond;
 }

--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -136,6 +136,7 @@ void print_help(bool detail = false)
 		"    -m          USBPATH Only monitor these paths.\n"
 		"                    -m 1:2 -m 1:3\n\n"
 		"    -t          Timeout second for wait known usb device appeared\n"
+		"    -pp         usb polling period in milliseconds\n"
 		"uuu -s          Enter shell mode. uuu.inputlog record all input commands\n"
 		"                you can use \"uuu uuu.inputlog\" next time to run all commands\n\n"
 		"uuu -udev       linux: show udev rule to avoid sudo each time \n"
@@ -874,6 +875,11 @@ int main(int argc, char **argv)
 			{
 				i++;
 				uuu_set_wait_timeout(atoll(argv[i]));
+			}
+			else if (s == "-pp")
+			{
+				i++;
+				uuu_set_poll_period(atoll(argv[i]));
 			}
 			else if (s == "-lsusb")
 			{


### PR DESCRIPTION
When upgrading the software on a closed device (tested on imx7ulp) the
USB device times out when trying to access OCRAM.

Allowing the client to customize the usb polling frequency allows the
upgrade script to complete without errors on all scenarios.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>